### PR TITLE
랜덤 밈 검색하기

### DIFF
--- a/memetionary/src/api/meme/index.ts
+++ b/memetionary/src/api/meme/index.ts
@@ -10,3 +10,12 @@ export const getMemeDetail = async ({ id }: { id: string }): Promise<Meme> => {
     throw error;
   }
 };
+
+export const getRandomMemeId = async () => {
+  try {
+    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_URL}/meme/random`);
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/memetionary/src/app/api/meme/random/route.ts
+++ b/memetionary/src/app/api/meme/random/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { memeList } from '@/app/api/meme/data';
+import { randomNum } from '@/utils/randomUtil';
+
+export const GET = async () => {
+  const randomMemeIndex = randomNum(0, memeList.length - 1);
+  const randomId = memeList[randomMemeIndex].id;
+
+  if (randomId) {
+    return NextResponse.json(randomId);
+  }
+
+  return NextResponse.json({ status: 500 });
+};

--- a/memetionary/src/app/contact/layout.tsx
+++ b/memetionary/src/app/contact/layout.tsx
@@ -1,7 +1,7 @@
 export default function ContactLayout({ children }: { children: React.ReactNode }) {
   const title = '이메일 문의하기';
   return (
-    <form className="grid h-screen w-full content-around p-8">
+    <form className="grid h-full w-full content-around p-8">
       <h2 className="text-3xl font-bold">{title}</h2>
       {children}
     </form>

--- a/memetionary/src/app/meme/[id]/page.tsx
+++ b/memetionary/src/app/meme/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function Meme({ params: { id } }: { params: { id: string } 
       {meme.video && <Video src={meme.video} />}
       <Example list={meme.example} />
       {meme.tags && <TagList list={meme.tags} />}
-      <div className="flex items-end justify-between">
+      <div className="flex flex-wrap items-end justify-between gap-2">
         <FooterDetail view={meme.view} lastUpdate={new Date(meme.lastUpdate)} />
         <DetailAction />
       </div>

--- a/memetionary/src/app/page.tsx
+++ b/memetionary/src/app/page.tsx
@@ -5,6 +5,7 @@ import { IconGood, IconLogo, IconMeme, IconOpinion } from '@/assets/icons';
 import Input from '@/components/Input';
 import Link from 'next/link';
 import { ChangeEvent, useState } from 'react';
+import RandomButtom from '@/components/RandomButton';
 
 export default function Home() {
   const [inputValue, setInputValue] = useState<string>('');
@@ -26,9 +27,7 @@ export default function Home() {
         <div className="flex w-full flex-col items-center gap-2">
           <Input onChange={handleInputChange} placeholder={`'어쩔티비'를 검색해보세요!`} />
           <div className="flex w-full gap-4">
-            <Button size="full" variant="outlined">
-              랜덤 밈 보기
-            </Button>
+            <RandomButtom type="text" />
             <Button size="full">
               <Link
                 className="flex h-full w-full items-center justify-center"

--- a/memetionary/src/components/Layout/Header/index.tsx
+++ b/memetionary/src/components/Layout/Header/index.tsx
@@ -1,5 +1,6 @@
-import { IconLogo, IconRandom, IconSearch } from '@/assets/icons';
 import Link from 'next/link';
+import RandomButtom from '@/components/RandomButton';
+import { IconLogo, IconSearch } from '@/assets/icons';
 
 const TITLE_TEXT = 'Memetionary';
 
@@ -13,11 +14,9 @@ const Header = () => {
         </div>
       </Link>
       <div className="flex items-center gap-3">
-        <Link href={'/'}>
-          <IconRandom />
-        </Link>
+        <RandomButtom type="icon" />
         <Link href={'/search'}>
-          <IconSearch />
+          <IconSearch width={16} height={16} />
         </Link>
       </div>
     </header>

--- a/memetionary/src/components/Layout/Main/index.tsx
+++ b/memetionary/src/components/Layout/Main/index.tsx
@@ -3,7 +3,7 @@ const Main = ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
-  return <main className="flex h-fit w-full min-w-80 max-w-192 flex-col items-center justify-center">{children}</main>;
+  return <main className="grid w-full min-w-80 max-w-192 flex-grow justify-items-center">{children}</main>;
 };
 
 export default Main;

--- a/memetionary/src/components/Meme/DetailAction/index.tsx
+++ b/memetionary/src/components/Meme/DetailAction/index.tsx
@@ -3,16 +3,13 @@ import ShareButton from '@/components/ShareButton';
 import { IconEnvelope } from '@/assets/icons';
 
 export default function DetailAction() {
-  const iconStyle = 'flex items-center gap-x-1';
   return (
-    <div className="flex items-center gap-x-2">
-      <Link href={'/contact'} className={iconStyle}>
+    <div className="flex items-center gap-3">
+      <Link href={'/contact'} className="flex items-center gap-1">
         <IconEnvelope width={18} height={18} />
         <span className="text-xs">문의하기</span>
       </Link>
-      <div className={iconStyle}>
-        <ShareButton position="top" showText />
-      </div>
+      <ShareButton position="top" showText />
     </div>
   );
 }

--- a/memetionary/src/components/Meme/Example/Bubble.tsx
+++ b/memetionary/src/components/Meme/Example/Bubble.tsx
@@ -5,14 +5,14 @@ interface BubbleProps {
   children: React.ReactNode;
 }
 
-export default function Bubble({ position, children }: BubbleProps) {
+export default function Bubble({ ...props }: BubbleProps) {
   return (
-    <div className={`flex gap-x-2 ${position === 'right' ? 'self-end' : ''}`}>
-      {position === 'left' && <IconUserRegular width={18} hanging={18} />}
-      <span className={`rounded-lg p-2 text-sm ${position === 'right' ? 'bg-violet-300' : 'bg-gray-300'}`}>
-        {children}
+    <div className={`flex gap-x-2 ${props.position === 'right' ? 'self-end' : ''}`}>
+      {props.position === 'left' && <IconUserRegular width={18} hanging={18} />}
+      <span className={`rounded-lg p-2 text-sm ${props.position === 'right' ? 'bg-violet-300' : 'bg-gray-300'}`}>
+        {props.children}
       </span>
-      {position === 'right' && <IconUserSolid width={18} hanging={18} />}
+      {props.position === 'right' && <IconUserSolid width={18} hanging={18} />}
     </div>
   );
 }

--- a/memetionary/src/components/Meme/Example/index.tsx
+++ b/memetionary/src/components/Meme/Example/index.tsx
@@ -1,18 +1,19 @@
 import Bubble from './Bubble';
 
 export interface ExampleProps {
-  id: number;
-  name: 'me' | 'you';
-  content: string;
+  list: {
+    id: number;
+    name: 'me' | 'you';
+    content: string;
+  }[];
 }
-[];
 
-export default function Example({ list }: { list: ExampleProps[] }) {
+export default function Example({ ...props }: ExampleProps) {
   return (
     <div className="grid gap-y-4">
       <h3 className="text-xl font-bold">사용 예시</h3>
-      <div className="rounded-lg bg-gray-100 px-14 py-8 ">
-        {list.reverse().map((e) => (
+      <div className="flex flex-col gap-y-4 rounded-lg bg-gray-100 p-8">
+        {props.list.reverse().map((e) => (
           <div key={e.id} className="flex flex-col">
             <Bubble position={e.name === 'me' ? 'right' : 'left'}>{e.content}</Bubble>
           </div>

--- a/memetionary/src/components/Meme/FooterDetail/index.tsx
+++ b/memetionary/src/components/Meme/FooterDetail/index.tsx
@@ -6,7 +6,7 @@ interface FooterDetailProps {
 }
 
 export default function FooterDetail({ ...props }: FooterDetailProps) {
-  const iconStyle = 'flex items-center gap-x-1';
+  const flexStyle = 'flex items-center gap-x-1';
 
   return (
     <div className="flex gap-x-2">
@@ -14,7 +14,7 @@ export default function FooterDetail({ ...props }: FooterDetailProps) {
         <span className="text-xs">조회수</span>
         <span className="text-xs">{props.view.toLocaleString()}</span>
       </div> */}
-      <div className={iconStyle}>
+      <div className={flexStyle}>
         <span className="text-xs">최근 수정시간</span>
         <span className="text-xs">{getLastUpdateTime(props.lastUpdate)}</span>
       </div>

--- a/memetionary/src/components/Meme/TagList/Tag.tsx
+++ b/memetionary/src/components/Meme/TagList/Tag.tsx
@@ -3,11 +3,13 @@ interface TagProps {
   children: React.ReactNode;
 }
 
-export default function Tag({ isDanger, children }: TagProps) {
+export default function Tag({ ...props }: TagProps) {
   const dangerStyle = 'bg-rose-500 text-white';
   return (
-    <div className={`w-fit rounded-lg border border-solid border-gray-200 p-2 text-xs ${isDanger ? dangerStyle : ''}`}>
-      {children}
+    <div
+      className={`w-fit rounded-lg border border-solid border-gray-200 p-2 text-xs ${props.isDanger ? dangerStyle : ''}`}
+    >
+      {props.children}
     </div>
   );
 }

--- a/memetionary/src/components/Meme/TagList/index.tsx
+++ b/memetionary/src/components/Meme/TagList/index.tsx
@@ -1,14 +1,16 @@
 import Tag from '@/components/Meme/TagList/Tag';
 
 export interface TagListProps {
-  type: 'info' | 'danger';
-  value: string;
+  list: {
+    type: 'info' | 'danger';
+    value: string;
+  }[];
 }
 
-export default function TagList({ list }: { list: TagListProps[] }) {
+export default function TagList({ ...props }: TagListProps) {
   return (
     <div className="flex flex-wrap gap-1">
-      {list.map((e) => (
+      {props.list.map((e) => (
         <Tag key={e.value} isDanger={e.type === 'danger'}>
           {e.value}
         </Tag>

--- a/memetionary/src/components/Meme/Thumbnail/index.tsx
+++ b/memetionary/src/components/Meme/Thumbnail/index.tsx
@@ -6,26 +6,26 @@ interface ThumbnailProps {
   size?: 'lg' | 'md';
 }
 
-export default function Thumbnail({ src, title, size }: ThumbnailProps) {
-  const sizeStyle = size === 'lg' ? 'h-80' : 'h-ful';
-  const textStyle = size === 'lg' ? 'text-4xl' : 'text-xl';
+export default function Thumbnail({ ...props }: ThumbnailProps) {
+  const sizeStyle = props.size === 'lg' ? 'h-80' : 'h-ful';
+  const textStyle = props.size === 'lg' ? 'text-4xl' : 'text-xl';
 
-  if (src) {
+  if (props.src) {
     return (
       <Image
         className="justify-self-center rounded-lg"
-        src={src}
+        src={props.src}
         width={600}
         height={320}
         loading="lazy"
-        alt={`${title}-thumbnail`}
+        alt={`${props.title}-thumbnail`}
       />
     );
   }
 
   return (
     <div className={`grid w-full place-items-center rounded-lg bg-primary-200 text-white ${sizeStyle}`}>
-      <h4 className={`bold font-semibold ${textStyle}`}>{title}</h4>
+      <h4 className={`bold font-semibold ${textStyle}`}>{props.title}</h4>
     </div>
   );
 }

--- a/memetionary/src/components/RandomButton/index.tsx
+++ b/memetionary/src/components/RandomButton/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Button from '@/components/Button';
+import { getRandomMemeId } from '@/api/meme';
+import { IconRandom } from '@/assets/icons';
+
+interface RandomButtonProps {
+  type: 'icon' | 'text';
+}
+
+export default function RandomButtom({ ...props }: RandomButtonProps) {
+  const router = useRouter();
+
+  const randomMeme = async () => {
+    const id = await getRandomMemeId();
+    router.push(`/meme/${id}`);
+  };
+
+  return props.type === 'icon' ? (
+    <IconRandom className="cursor-pointer" width={16} height={16} onClick={randomMeme} />
+  ) : (
+    <Button size="full" variant="outlined" onClick={randomMeme}>
+      랜덤 밈 보기
+    </Button>
+  );
+}

--- a/memetionary/src/components/Select/index.tsx
+++ b/memetionary/src/components/Select/index.tsx
@@ -4,8 +4,8 @@ interface SelectProps extends DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectE
   options: string[];
 }
 
-export default function Select({ options, ...props }: SelectProps) {
-  const optionType = options[0];
+export default function Select({ ...props }: SelectProps) {
+  const optionType = props.options[0];
   const [value, setValue] = useState(optionType);
 
   const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = (e) => {
@@ -20,7 +20,7 @@ export default function Select({ options, ...props }: SelectProps) {
 
   return (
     <select {...props} value={value} onChange={handleChangeSelect}>
-      {options.map((e, i) => (
+      {props.options.map((e, i) => (
         <option key={e} value={e} disabled={i === 0}>
           {e}
         </option>

--- a/memetionary/src/components/TextArea/index.tsx
+++ b/memetionary/src/components/TextArea/index.tsx
@@ -6,7 +6,7 @@ interface TextAreaProps extends DetailedHTMLProps<TextareaHTMLAttributes<HTMLTex
 
 const TEXTAREA_MAX_LENGTH = 500;
 
-export default function TextArea({ showTextLength, ...props }: TextAreaProps) {
+export default function TextArea({ showTextLength, className, ...props }: TextAreaProps) {
   const [value, setValue] = useState('');
 
   const handleTextarea: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
@@ -20,8 +20,14 @@ export default function TextArea({ showTextLength, ...props }: TextAreaProps) {
   }, [props.value]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <textarea {...props} value={value} onChange={handleTextarea} />
+    <div className="flex h-72 flex-col gap-2">
+      <textarea
+        className={`resize-none ${className}`}
+        value={value}
+        onChange={handleTextarea}
+        {...props}
+        maxLength={props.maxLength}
+      />
       {showTextLength && (
         <span className="self-end text-sm text-gray-400">{`${value.length}/${TEXTAREA_MAX_LENGTH}`}</span>
       )}

--- a/memetionary/src/components/Video/index.tsx
+++ b/memetionary/src/components/Video/index.tsx
@@ -20,12 +20,12 @@ export default function Video({ ...props }: VideoProps) {
   const embededLink = replaceEmbededLink(props.src);
 
   return (
-    <div className="grid gap-y-4">
+    <div className="relative grid w-full gap-y-4 pb-[56.25%] pt-[30px]">
       <h3 className="text-xl font-bold">관련 이미지 및 동영상</h3>
       <iframe
-        className="justify-self-center"
-        width="560"
-        height="315"
+        className="absolute h-[80%] w-full justify-self-center"
+        width="100%"
+        height="auto"
         src={embededLink}
         title="YouTube video player"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/memetionary/src/hooks/useForm.ts
+++ b/memetionary/src/hooks/useForm.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export const useForm = <T>(initForm: T) => {
+  const [form, setForm] = useState<typeof initForm>(initForm);
+
+  const handleChangeForm = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+    setForm((prev: typeof initForm) => ({ ...prev, [target.id]: target.value }));
+  };
+
+  return {
+    form,
+    setForm,
+    handleChangeForm,
+  };
+};

--- a/memetionary/src/utils/randomUtil.ts
+++ b/memetionary/src/utils/randomUtil.ts
@@ -1,0 +1,3 @@
+export const randomNum = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/memetionary/src/utils/validator/contactForm.ts
+++ b/memetionary/src/utils/validator/contactForm.ts
@@ -1,4 +1,3 @@
-import { ContactForm } from '@/app/contact/page';
 import Z from '@/utils/validator';
 
 const MIN_CONTENT_NUM = 10;
@@ -9,7 +8,3 @@ const ContactForm = Z.object({
   title: new Z().min({ num: 1, message: '제목을 입력해주세요.' }),
   content: new Z().min({ num: MIN_CONTENT_NUM, message: `문의 내용을 최소 ${MIN_CONTENT_NUM}자 이상 입력해주세요` }),
 });
-
-export const validateContactForm = (form: ContactForm) => {
-  return ContactForm.parse(form);
-};

--- a/memetionary/src/utils/validator/index.ts
+++ b/memetionary/src/utils/validator/index.ts
@@ -58,3 +58,12 @@ class Z {
 }
 
 export default Z;
+
+export const validateForm = (schema: Schema, form: Record<string, any>) => {
+  const inValid = schema.parse(form);
+  if (inValid) {
+    alert(inValid);
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## Summary
랜덤 밈 검색하기
- 헤더의 랜덤 아이콘 또는 메인페이지 랜덤 밈 검색하기 버튼 클릭시 랜덤으로 밈을 조회할 수 있다. 

## Desribe your changes
### 1. 랜덤 밈 보기
밈 데이터가 DB에서 삭제될 경우를 고려해 서버에서 랜덤한 id를 넘겨주는 것으로 구현했습니다. 

### 2. useForm 커스텀훅 
추후 밈 생성하기 등에 사용될 수 있는 form 형태의 state를 관리하기 위해 관련 로직을 커스텀 훅으로 분리했습니다.

### 3. Main Layout 수정 (flex -> grid)
Contact 페이지를 100vh로 설정하기 위해 레이아웃을 grid로 수정했습니다.

### 4. rest props
회의에서 다룬 것과 같이 컴포넌트의 Props 형태를 rest로 통일했습니다. 

## Issue number and Link
closed #16 