### PR TITLE
🐛 동적 페이지 설정으로 빌드 오류 해결

### DIFF
--- a/memetionary/src/app/search/[keyword]/page.tsx
+++ b/memetionary/src/app/search/[keyword]/page.tsx
@@ -8,6 +8,8 @@ import Pagination from '@/components/Pagination';
 import { useRouter, useParams } from 'next/navigation';
 import { ChangeEvent, KeyboardEvent, useEffect, useState } from 'react';
 
+export const dynamic = 'force-dynamic';
+
 export default function SearchResultPage() {
   const router = useRouter();
   const { keyword } = useParams<{ keyword: string }>();

--- a/memetionary/src/app/test/page.tsx
+++ b/memetionary/src/app/test/page.tsx
@@ -9,6 +9,8 @@ import Title from '@/components/Test/Title';
 const TEST_ID = 1;
 const MOCK_ANSWER = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2];
 
+export const dynamic = 'force-dynamic';
+
 export default async function Test() {
   const { tester_count, share_count } = await getTestCount({ id: TEST_ID });
 


### PR DESCRIPTION
## Summary
동적 페이지를 설정하여 정적 페이지 빌드시 오류를 해결합니다. 

오류가 나는 페이지에 다음 코드를 추가하였습니다.
```
export const dynamic = "force-dynamic";
```

## 참고 링크
https://kyechan99.github.io/post/memo/nextjs-fetch-failed